### PR TITLE
Fix join_date on user authentication event

### DIFF
--- a/src/main/java/org/chameleoncloud/ChameleonAddJoinDate.java
+++ b/src/main/java/org/chameleoncloud/ChameleonAddJoinDate.java
@@ -3,6 +3,8 @@ package org.chameleoncloud;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jboss.logging.Logger;
+
 import org.keycloak.Config;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionFactory;
@@ -14,9 +16,12 @@ import org.keycloak.models.UserModel;
 
 public class ChameleonAddJoinDate implements RequiredActionProvider, RequiredActionFactory {
 
+  // convention seems to indicate that this SHOULD_BE_ALL_CAPS
   public static final String PROVIDER_ID = "chameleon_add_join_date";
 
   public static final String USER_ATTRIBUTE = "joinDate";
+
+  private static final Logger logger = Logger.getLogger(ChameleonAddJoinDate.class);
 
   @Override
   public void close() {
@@ -25,22 +30,37 @@ public class ChameleonAddJoinDate implements RequiredActionProvider, RequiredAct
 
   @Override
   public void evaluateTriggers(final RequiredActionContext context) {
+    // evaluateTriggers should update to look at the user and see if the join date
+    // field is set. If not set, it should add the set join date as a required
+    // action
     final UserModel user = context.getUser();
-    final List<String> list = user.getAttribute(USER_ATTRIBUTE);
+    final String join_date = user.getFirstAttribute(USER_ATTRIBUTE);
 
-    if (list == null || list.isEmpty()) {
-      user.setAttribute(USER_ATTRIBUTE, Arrays.asList(Integer.toString(Time.currentTime())));
+    // Check if attribute is empty
+    if (join_date == null || join_date.isEmpty()) {
+      logger.debug("Join date is not set, adding required action");
+      context.getUser().addRequiredAction(PROVIDER_ID);
     }
   }
 
   @Override
   public void requiredActionChallenge(RequiredActionContext context) {
-    // NOOP
+    final UserModel user = context.getUser();
+
+    final String join_date = user.getFirstAttribute(USER_ATTRIBUTE);
+
+    // Don't overwrite join date if the required action gets re-run
+    if (join_date == null || join_date.isEmpty()) {
+      logger.debug("Setting Join Date to Now.");
+      user.setSingleAttribute(USER_ATTRIBUTE, Integer.toString(Time.currentTime()));
+      // Set context.success here, to prevent user interaction.
+    }
+    context.success();
   }
 
   @Override
   public void processAction(final RequiredActionContext context) {
-    context.success();
+    // NOOP
   }
 
   @Override


### PR DESCRIPTION
Set join date in RequiredActionChallenge instead of in processAction.
processAction is only called when a form is submitted, but this is
noninteractive.

if join date is not set, evaluateTriggers sets adds
requiredActionChallenge to the list of required actions.