### PR TITLE
Authenticate by matching linked Identity to globus session identity_set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,10 @@ build:
 .PHONY: publish
 publish:
 	mvn deploy -Dregistry=https://maven.pkg.github.com/ChameleonCloud
+
+target/keycloak-chameleon.jar: build
+	mvn -B package
+
+.PHONY
+deploy-dev: target/keycloak-chameleon.jar
+	scp target/keycloak-chameleon.jar admin02.uc.chameleoncloud.org:~/

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>10</source>
-                        <target>10</target>
+                        <release>11</release>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <resteasy.version>3.11.2.Final</resteasy.version>
         <keycloak.version>10.0.2</keycloak.version>
         <!-- the version of this build and all depending projects -->
-        <revision>1.3.5</revision>
+        <revision>1.3.6-SNAPSHOT</revision>
     </properties>
 
     <build>

--- a/src/main/java/org/chameleoncloud/IdpLinkIdentitySetAuthenticator.java
+++ b/src/main/java/org/chameleoncloud/IdpLinkIdentitySetAuthenticator.java
@@ -1,0 +1,105 @@
+package org.chameleoncloud;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.logging.Logger;
+import java.util.List;
+import java.util.Map;
+
+import org.chameleoncloud.representations.GlobusIdentity;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.KeycloakSession;
+
+import org.keycloak.representations.JsonWebToken;
+
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public class IdpLinkIdentitySetAuthenticator extends AbstractIdpAuthenticator {
+
+    String IDENTITY_SET_CLAIM = "identity_set";
+    // String GLOBUS_ALIAS = "globus";
+
+    private static Logger logger = Logger.getLogger(IdpLinkIdentitySetAuthenticator.class);
+
+    @Override
+    protected void authenticateImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx,
+            BrokeredIdentityContext brokerContext) {
+
+        KeycloakSession session = context.getSession();
+        RealmModel realm = context.getRealm();
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        String providerId = brokerContext.getIdpConfig().getAlias();
+
+        List<GlobusIdentity> identitySet = getIdentitiesFromToken(brokerContext);
+
+        FederatedIdentityModel newIdentity = new FederatedIdentityModel(providerId, brokerContext.getId(),
+                brokerContext.getUsername(), brokerContext.getToken());
+
+        for (GlobusIdentity identity : identitySet) {
+            // create model from identity parameters
+            FederatedIdentityModel oldIdentity = new FederatedIdentityModel(providerId, identity.getSub(),
+                    identity.getUsername(), brokerContext.getToken());
+            logger.warnv("Checking for existing users with {0} sub matching {1}", oldIdentity.getIdentityProvider(),
+                    oldIdentity.getUserId());
+
+            UserModel federatedUser = session.users().getUserByFederatedIdentity(oldIdentity, realm);
+            if (federatedUser != null) {
+                logger.warnv("Username {0} has existing link with provider {1}, removing linked id {2}",
+                        federatedUser.getUsername(), providerId, oldIdentity.getUserId());
+                // TODO: Handle duplicate globus case
+                // Link existing user to this token
+                // session.users().updateFederatedIdentity(realm, federatedUser, newIdentity);
+                session.users().removeFederatedIdentity(realm, federatedUser, providerId);
+                context.setUser(federatedUser);
+                context.success();
+                return;
+            } else {
+                logger.warnv("No match found for {0} username {1}", oldIdentity.getIdentityProvider(),
+                        oldIdentity.getUserName());
+            }
+        }
+
+        logger.warnv("No match in identity set for found for {0} username {1}", providerId,
+                brokerContext.getUsername());
+        context.attempted();
+
+        // TODO match on username / email of existing accounts from identityset
+
+    }
+
+    private List<GlobusIdentity> getIdentitiesFromToken(BrokeredIdentityContext brokerContext) {
+        JsonWebToken token = (JsonWebToken) brokerContext.getContextData().get(OIDCIdentityProvider.VALIDATED_ID_TOKEN);
+        Map<String, Object> otherClaims = token.getOtherClaims();
+        ObjectMapper mapper = new ObjectMapper();
+        List<GlobusIdentity> identity_set = mapper.convertValue(otherClaims.get(this.IDENTITY_SET_CLAIM),
+                new TypeReference<List<GlobusIdentity>>() {
+                });
+        return identity_set;
+    }
+
+    @Override
+    protected void actionImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx,
+            BrokeredIdentityContext brokerContext) {
+        authenticateImpl(context, serializedCtx, brokerContext);
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return false;
+    }
+}

--- a/src/main/java/org/chameleoncloud/IdpLinkIdentitySetAuthenticatorFactory.java
+++ b/src/main/java/org/chameleoncloud/IdpLinkIdentitySetAuthenticatorFactory.java
@@ -1,0 +1,77 @@
+package org.chameleoncloud;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class IdpLinkIdentitySetAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "link-user-in-identityset";
+    private static final IdpLinkIdentitySetAuthenticator SINGLETON = new IdpLinkIdentitySetAuthenticator();
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "autoLink";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "IdP Link Identity if in IdentitySet";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "If existing user has linked identity in the identity set, override that link.";
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return null;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+}

--- a/src/main/java/org/chameleoncloud/representations/GlobusIDToken.java
+++ b/src/main/java/org/chameleoncloud/representations/GlobusIDToken.java
@@ -1,0 +1,67 @@
+package org.chameleoncloud.representations;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.representations.IDToken;
+
+public class GlobusIDToken extends IDToken {
+    /*
+     * openid: Requests that an OpenID Connect id_token be returned as part of the
+     * OAuth2 Access Token Response, with the following claims: sub: The Globus Auth
+     * identity id of the effective identity of the logged in Globus account. This
+     * effective may be the primary identity, or the appropriate linked identity if
+     * this client requires an identity from a particular provider. iss: The URL
+     * "https://auth.globus.org" at_hash: Per OpenID Connect specification. aud: Per
+     * OpenID Connect specification. exp: Per OpenID Connect specification. iat: Per
+     * OpenID Connect specification. nonce: Per OpenID Connect specification.
+     * last_authentication: The last time that this identity authenticated, returned
+     * as a Unix/epoch timestamp. identity_set: The identities linked to this
+     * account.
+     * 
+     * email: Adds the following claim in the id_token: email: The email address
+     * associated with the identity provided in the "sub" claim.
+     * 
+     * profile: Adds the following claim in the id_token: name: The identity’s full
+     * name (e.g. Jane Doe) in displayable form. organization: The identity’s
+     * organization. preferred_username: The identity username for the effective
+     * identity ID provided by the 'sub' claim. identity_provider: The ID of the
+     * identity provider for this identity. identity_provider_display_name: The name
+     * of the identity provider for this identity.
+     */
+
+    @JsonProperty("last_authentication")
+    protected Long last_authentication;
+
+    public Long getLastAuthentication() {
+        return this.last_authentication;
+    }
+
+    @JsonProperty("identity_set")
+    protected GlobusIdentity[] identity_set;
+
+    public GlobusIdentity[] getIdentitySet() {
+        return this.identity_set;
+    }
+
+    @JsonProperty("organization")
+    protected String organization;
+
+    public String getOrganization() {
+        return this.organization;
+    }
+
+    @JsonProperty("identity_provider_display_name")
+    protected String identity_provider_display_name;
+
+    public String getIdentityProviderDisplayName() {
+        return this.identity_provider_display_name;
+    }
+
+    @JsonProperty("identity_provider")
+    protected String identity_provider;
+
+    public String getIdentityProvider() {
+        return this.identity_provider;
+    }
+}

--- a/src/main/java/org/chameleoncloud/representations/GlobusIdentity.java
+++ b/src/main/java/org/chameleoncloud/representations/GlobusIdentity.java
@@ -1,0 +1,63 @@
+package org.chameleoncloud.representations;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GlobusIdentity {
+
+    @JsonProperty("name")
+    protected String name;
+
+    @JsonProperty("username")
+    protected String username;
+
+    @JsonProperty("identity_provider_display_name")
+    protected String identity_provider_display_name;
+
+    @JsonProperty("identity_provider")
+    protected String identity_provider;
+
+    @JsonProperty("last_authentication")
+    protected Long last_authentication;
+
+    @JsonProperty("sub")
+    protected String sub;
+
+    @JsonProperty("email")
+    protected String email;
+
+    @JsonProperty("organization")
+    protected String organization;
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public String getIdentityProviderDisplayName() {
+        return this.identity_provider_display_name;
+    }
+
+    public String getIdentityProvider() {
+        return this.identity_provider;
+    }
+
+    public Long getLastAuthentication() {
+        return this.last_authentication;
+    }
+
+    public String getSub() {
+        return this.sub;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public String getOrganization() {
+        return this.organization;
+    }
+
+}

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,2 @@
+# List here all authenticators which should be loaded by Keycloak.
+org.chameleoncloud.IdpLinkIdentitySetAuthenticatorFactory


### PR DESCRIPTION
### add new authenticator to handle linked globus IDs
This authenticator handles the case where a user creates a chameleon
account with a globus identity, then later links that identity to a new
primary globus account.

When authenticating, globus returns a token containing all associated,
validated identities. If one of those identities matches the one linked
to an existing chameleon user, it is safe to update the linked identity
to the new one.

This commit adds an authenticator to be used in the "broker first login"
flow, and will update an existing user, if and only if an exact match is
found for the linked identity.

Since keycloak cannot handle multiple copies of an IdP linked to a user,
we must delete the linked identity, then re-link the new one.
This is done by attaching the found user to the authentication session,
then returning success.

To avoid orphaning accounts, the deletion and linking must happen
atomically. For example, if a confirmation step was required to link,
the deletion could happen without the relinking.

### check for username and email matches in identitySet
This adds checks for matching username and email, not just linked
identity. However, we cannot assume that a match means the user is
authenticated in this case, and an additional confirmation step is
needed.

Therefore, in these cases, we set "ExistingUserInfo" to the
authentication context, and set context.attempted. This delegates
conflict handling to later authenticators in the flow.

A "sane" flow to handle this can be seen in the default "broker first
login" flow, under "handle existing account". It first prompts the user
to confirm account linking, then emails the listed contact email on the
account for confirmation.

### Add attribute mapper for OIDC identity_set
The identity set can be provided by either the id_token, or the userinfo
endpoint. This is agnostic to that, and maps the identity_set fields
to user_attributes on login. This is triggered before the 
"first broker login flow", and allows us to do custom mapping if needed.

TODO:
The case that is currently unhandled is if a user authenticates with a
new globus account, but alreday has one configured. The
verifyEmailAuthenticator must be modified to handle the duplicate IDP entry.